### PR TITLE
fix generated code to dart 2.9

### DIFF
--- a/auto_route_generator/lib/router_class_generator.dart
+++ b/auto_route_generator/lib/router_class_generator.dart
@@ -15,6 +15,7 @@ class RouterClassGenerator {
   void _newLine() => _stringBuffer.writeln();
 
   String generate() {
+    _writeln("// @dart=2.9");
     _writeln("// ignore_for_file: public_member_api_docs");
     var allRouters = _rootRouterConfig.collectAllRoutersIncludingParent;
     var allRoutes = allRouters.fold<List<RouteConfig>>(

--- a/auto_route_generator/pubspec.yaml
+++ b/auto_route_generator/pubspec.yaml
@@ -7,11 +7,11 @@ environment:
   sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
-  build: ^1.0.0
+  build: ^2.0.0
   source_gen: ^0.9.0
   analyzer: ">=0.40.0 <2.0.0"
   path: ^1.6.4
-  build_runner: ^1.10.1
+  build_runner: ^1.11.5
   auto_route: ^0.6.9
 #    path: ../auto_route
 


### PR DESCRIPTION
fix generated code to dart 2.9 since the package does not yet generate null safety code